### PR TITLE
ENH: full support for validating QIIME 2 mapping files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 **Note on versioning:** the version numbers used here match the version numbers displayed to users in the Chrome Web Store. Sometimes there are gaps between release versions (e.g., version 2 jumps to version 5). This happens because each separate upload of Keemei to the web store increments the version number, and sometimes multiple uploads are necessary before a release is finalized (e.g., if the release is reviewed by an add-ons advisor and updates are required before it can go public). Therefore, the version numbering used here in the changelog and tagged GitHub releases will match the public release version displayed in the web store.
 
+## Version 14 (2017-07-25)
+
+This release adds full support for validating [QIIME 2](https://qiime2.org) mapping files.
+
+### Features
+* Added full support for validating [QIIME 2 mapping files](https://docs.qiime2.org/2017.7/tutorials/metadata/#metadata-from-a-text-file)
+
 ## Version 13 (2017-06-28)
 
 This release adds **experimental** support for validating [QIIME 2](https://qiime2.org) mapping files.

--- a/src/Qiime1Format.gs
+++ b/src/Qiime1Format.gs
@@ -8,8 +8,7 @@ function getQiime1FormatSpec_(sheetData) {
 
   return {
     format: "QIIME 1 mapping file",
-    headerRowIdx: 0,
-    dataStartRowIdx: getQiime1DataStartRowIdx_(sheetData),
+    ignoredRowIdxs: getQiime1IgnoredRowIdxs_(sheetData),
     headerValidation: [
       {
         validator: findMissingValues_,
@@ -121,13 +120,17 @@ function getPrimerValidators_() {
   ];
 };
 
-function getQiime1DataStartRowIdx_(sheetData) {
+function getQiime1IgnoredRowIdxs_(sheetData) {
+  var ignored = new Array(sheetData.length);
   for (var i = 1; i < sheetData.length; i++) {
-    if (!startsWith_(sheetData[i][0], "#")) {
+    if (startsWith_(sheetData[i][0], "#")) {
+      ignored[i] = true;
+    }
+    else {
       break;
     }
   }
-  return i;
+  return ignored;
 };
 
 function findInvalidQiime1Columns_(valueToPositions, ignoredValues) {

--- a/src/QiitaSampleTemplateFormat.gs
+++ b/src/QiitaSampleTemplateFormat.gs
@@ -5,8 +5,7 @@ function getQiitaSampleTemplateFormatSpec_(sheetData) {
 
   return {
     format: "Qiita sample template",
-    headerRowIdx: 0,
-    dataStartRowIdx: 1,
+    ignoredRowIdxs: [],
     headerValidation: [
       {
         validator: findMissingValues_,

--- a/src/SrgdFormat.gs
+++ b/src/SrgdFormat.gs
@@ -1,8 +1,7 @@
 function getSrgdFormatSpec_(sheetData) {
   return {
     format: "SRGD",
-    headerRowIdx: 0,
-    dataStartRowIdx: 1,
+    ignoredRowIdxs: [],
     headerValidation: [
       {
         validator: findMissingSrgdFields_,


### PR DESCRIPTION
Validation rules match those described in QIIME 2 2017.7 docs, including support for comments:

https://docs.qiime2.org/2017.7/tutorials/metadata/#metadata-from-a-text-file